### PR TITLE
Change go.mod's module name so it can be imported.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dghubble/go-twitter
+module github.com/drswork/go-twitter
 
 go 1.17
 


### PR DESCRIPTION
Looks like module cannot be imported due to `go.mod` having the original package name.

<img width="676" alt="Screenshot 2022-06-18 at 11 39 38" src="https://user-images.githubusercontent.com/1078546/174434095-baf8abeb-46dc-4156-8eec-be97d2aadf24.png">
